### PR TITLE
Correct the number of bits for PPS in avcC

### DIFF
--- a/scripts/mp4.hm
+++ b/scripts/mp4.hm
@@ -913,7 +913,7 @@ class AVCConfigurationBox as Box("avcC")
 	bit(3)  reserved;
 	uint(5) numOfSequenceParameterSets;
 	AVCSequence sequences[numOfSequenceParameterSets];
-	uint(5) numOfPictureParameterSets;
+	uint(8) numOfPictureParameterSets;
 	AVCPicture pictures[numOfPictureParameterSets];
 }
 


### PR DESCRIPTION
According to ISO 14496-15:2004, section 5.2.4.1.1, this field
is 8 bits long.
