### PR TITLE
Fix the declaration of TrackFragmentRandomAccessEntry (in tfra) in MP4

### DIFF
--- a/scripts/mp4.hm
+++ b/scripts/mp4.hm
@@ -604,7 +604,8 @@ extends Data(2*size + traf_size + trun_size + sample_size)
 	uint(@args.size)      time;
 	uint(@args.size)      moof_offset;
 	uint(@args.traf_size) traf_number;
-	uint(@args.trun_size) sample_number;
+	uint(@args.trun_size) trun_number;
+	uint(@args.sample_size) sample_number;
 }
 
 class TrackFragmentRandomAccessBox extends FullBox as Box("tfra")


### PR DESCRIPTION
The size of the box contained all fields, but one of the fields was
misnamed and one was missing.
